### PR TITLE
Trapezoidal Motion Profiles

### DIFF
--- a/eqn/.gitignore
+++ b/eqn/.gitignore
@@ -1,0 +1,15 @@
+/sage-plots-for-*/
+*.sage
+*.sage.py
+
+.auctex-auto/
+*.aux
+*.dvi
+*.log
+*.scmd
+*.sout
+*.pdf
+
+.python-version
+
+outputs.txt

--- a/eqn/hack/clean
+++ b/eqn/hack/clean
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+for ext in aux dvi log scmd sout pdf sagetex.sage sagetex.sage.py; do
+    rm -f "$script_dir/../"*.$ext
+done
+
+rm -rf "$script_dir/../.auctex-auto"
+rm -f "$script_dir/../outputs.txt"
+rm -rf "$script_dir/../sage-plots-for-"*
+

--- a/eqn/hack/watch-latex
+++ b/eqn/hack/watch-latex
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [[ "$#" -ne 1 ]]; then
+    echo >&2 "usage: watch-latex <filename>"
+    exit 1
+fi
+
+file="$1"
+
+export TEXINPUTS="${CONDA_PREFIX}/share/texmf/tex/latex/sagetex/:"
+
+process() {
+    base="${0%.tex}"
+    rm -f "${base}.sagetex.*"
+    pdflatex -draftmode "$0"
+    sage "${base}.sagetex.sage"
+    pdflatex "$0"
+}
+export -f process
+
+echo "$file" | entr -cr bash -c '
+    set -e
+    process
+' "$file"

--- a/eqn/intercept.tex
+++ b/eqn/intercept.tex
@@ -1,0 +1,183 @@
+
+\documentclass{article}
+\usepackage{sagetex}
+\usepackage{array}
+\usepackage{breqn}
+\usepackage{cancel}
+\usepackage{comment}
+\usepackage[top=1in,bottom=1in]{geometry}
+\usepackage{multicol}
+\usepackage{sageutil}
+\setlength{\columnsep}{20pt}
+\setlength{\parskip}{\baselineskip}%
+\setlength{\parindent}{0pt}%
+\begin{document}
+
+\begin{sagesilent}
+  from sage.misc.latex import latex_variable_name
+  def colorvar(s, color=None):
+    prefix = ""
+    if color is not None:
+      prefix = f"\\color[HTML]{{{color.html_color()[1:]}}}"
+
+    return [
+      var(v, latex_name=f"{prefix}{{{latex_variable_name(v)}}}")
+      for v in s.replace(",", " ").split(" ")
+      if v != ""
+    ]
+
+  colorvar("a_in, a_out, c, p_i, v_i, v_f, q_i, u", Color("gray"))
+  colorvar("s_in, s_out, s_c, p_f", Color("aqua"))
+  colorvar("v_c t", Color("orange"))
+  colorvar("s", Color("lime"))
+  colorvar("t_in, t_c, t_out", Color("magenta"))
+\end{sagesilent}
+
+\begin{sagesilent}
+  final_pos = p_f == p_i + s
+  displacement = s == s_in + s_c + s_out
+  tgt_final_pos = p_f == q_i + u * t
+  in_disp = s_in == t_in * (v_i + v_c) / 2
+  out_disp = s_out == t_out * (v_c + v_f) / 2
+  cruise_disp = s_c == v_c * t_c
+
+  cruise_vel_sq = v_c**2 == v_i**2 + 2 * a_in * s_in
+  final_vel_sq = v_f**2 == v_c**2 + 2 * a_out * s_out
+
+  total_time = t == t_in + t_c + t_out
+\end{sagesilent}
+
+Final Position
+\sagenamed{final_pos}
+Displacement
+\sagenamed{displacement}
+Total Time
+\sagenamed{total_time}
+Target Final Position
+\sagenamed{tgt_final_pos}
+Ramp In Displacement
+\sagenamed{in_disp}
+Ramp Out Displacement
+\sagenamed{out_disp}
+Cruise Displacement
+\sagenamed{cruise_disp}
+
+Cruise Velocity Squared
+\sagenamed{cruise_vel_sq}
+Final Velocity Squared
+\sagenamed{final_vel_sq}
+
+\hrule
+
+\begin{sagesilent}
+head = final_pos
+head = step1 = head.subs(s=displacement.right())
+\end{sagesilent}
+
+Substitute \sageref{displacement} for $\sage{s}$ into \sageref{final_pos}
+\sagenamed{step1}
+
+\begin{sagesilent}
+head = step2 = head.subs(p_f=tgt_final_pos.right())
+\end{sagesilent}
+
+Substitute \sageref{tgt_final_pos} for $\sage{p_f}$
+\sagenamed{step2}
+
+\begin{sagesilent}
+head = step3 = head.subs(
+  s_c=cruise_disp.solve(s_c)[0].right()
+)
+\end{sagesilent}
+
+Substitute \sageref{cruise_disp} for $\sage{s_c}$
+\sagenamed{step3}
+
+\begin{sagesilent}
+head = step4 = head.subs(
+  t_c=total_time.solve(t_c)[0].right()
+)
+\end{sagesilent}
+
+Substitute \sageref{total_time} for $\sage{t_c}$
+\sagenamed{step4}
+
+\begin{sagesilent}
+head = step5 = head.subs(
+  t_in=in_disp.solve(t_in)[0].right(),
+  t_out=out_disp.solve(t_out)[0].right(),
+)
+\end{sagesilent}
+
+Substitute \sageref{in_disp} for $\sage{t_in}$ and \sageref{out_disp} for $\sage{t_out}$
+\sagenamed{step5}
+
+\begin{sagesilent}
+head = step6 = head.subs(
+  s_in=cruise_vel_sq.solve(s_in)[0].right(),
+  s_out=final_vel_sq.solve(s_out)[0].right(),
+)
+\end{sagesilent}
+
+Substitute \sageref{cruise_vel_sq} for $\sage{s_in}$ and \sageref{final_vel_sq} for $\sage{s_out}$
+\sagenamed{step6}
+
+\begin{sagesilent}
+  T(v_c) = head.solve(t)[0].right()
+\end{sagesilent}
+
+Solve for t to produce $T(\sage{v_c})$
+\sagenamed{T}
+
+\begin{sagesilent}
+  # Write the roots of the derivative of T(v_c) with respect to v_c to
+  # outputs.txt in a convenient format for copy-pasting into python.
+  v_c_roots = T(v_c).diff(v_c).solve(v_c)
+  with open("outputs.txt", "w") as f:
+    f.write("T(v_c)\n")
+    f.write(str(T).replace("^", "**"))
+    f.write("\n")
+
+    f.write("\n")
+
+    f.write("vc roots\n")
+    f.write(str(v_c_roots).replace("^", "**"))
+    f.write("\n")
+\end{sagesilent}
+
+\begin{comment}
+
+\hrule
+
+\begin{sagesilent}
+  params=dict(
+    # ramp in/out
+    a_in=5,
+    a_out=-10,
+
+    # initial position/velocity
+    p_i=10,
+    v_i=3,
+
+    # final velocity (often equal to u)
+    v_f=3,
+
+    # initial target position and velocity
+    q_i=100,
+    u=3,
+  )
+
+  best_vc = vc_roots[1](**params)
+
+  intercept_t = T(**params, v_c = best_vc.right())
+\end{sagesilent}
+
+Best $\sage{v_c}$
+$$\sage{best_vc} = \sage{best_vc.right().n(digits=5)}$$
+
+$t_{intercept}$
+$$\sage{intercept_t} = \sage{intercept_t.n(digits=5)}$$
+
+\end{comment}
+
+\end{document}

--- a/eqn/intercept.tex
+++ b/eqn/intercept.tex
@@ -130,6 +130,15 @@ Solve for t to produce $T(\sage{v_c})$
 \sagenamed{T}
 
 \begin{sagesilent}
+
+solved_for_v_c = head.solve(v_c)
+
+\end{sagesilent}
+
+\sagenamed{solved_for_v_c[0]}
+\sagenamed{solved_for_v_c[1]}
+
+\begin{sagesilent}
   # Write the roots of the derivative of T(v_c) with respect to v_c to
   # outputs.txt in a convenient format for copy-pasting into python.
   v_c_roots = T(v_c).diff(v_c).solve(v_c)
@@ -143,6 +152,10 @@ Solve for t to produce $T(\sage{v_c})$
     f.write("vc roots\n")
     f.write(str(v_c_roots).replace("^", "**"))
     f.write("\n")
+
+    f.write("\n")
+    f.write("vc in terms of t\n")
+    f.write(str(solved_for_v_c).replace("^", "**"))
 \end{sagesilent}
 
 \begin{comment}

--- a/eqn/sageutil.sty
+++ b/eqn/sageutil.sty
@@ -1,0 +1,5 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{sageutil}[2023/11/09 Sage Utilities]
+
+\newcommand{\sagenamed}[1]{\begin{equation}\label{sageeq:#1}\sage{#1}\end{equation}}
+\newcommand{\sageref}[1]{(\ref{sageeq:#1})}

--- a/poetry.lock
+++ b/poetry.lock
@@ -56,6 +56,31 @@ test = ["pytest (>=7.0,<8)", "pytest-astropy (>=0.10)", "pytest-astropy-header (
 test-all = ["coverage[toml]", "ipython (>=4.2)", "objgraph", "pytest (>=7.0,<8)", "pytest-astropy (>=0.10)", "pytest-astropy-header (>=0.2.1)", "pytest-doctestplus (>=0.12)", "pytest-xdist", "sgp4 (>=2.3)", "skyfield (>=1.20)"]
 
 [[package]]
+name = "astroquery"
+version = "0.4.6"
+description = "Functions and classes to access online astronomical data resources"
+optional = false
+python-versions = "*"
+files = [
+    {file = "astroquery-0.4.6-py3-none-any.whl", hash = "sha256:e1bc4996af7500370837d31491bd4ee7f0c954c78d24cd54fb1cceb755469094"},
+    {file = "astroquery-0.4.6.tar.gz", hash = "sha256:307ca554cb734a0ca9a22f86f5effe7e413af913ae65e1578972d847b1fe13ee"},
+]
+
+[package.dependencies]
+astropy = ">=4.0"
+beautifulsoup4 = ">=4.3.2"
+html5lib = ">=0.999"
+keyring = ">=4.0"
+numpy = ">=1.16"
+pyvo = ">=1.1"
+requests = ">=2.4.3"
+
+[package.extras]
+all = ["aplpy", "astropy-healpix", "boto3", "mocpy (>=0.5.2)", "pyregion", "regions"]
+docs = ["scipy", "sphinx-astropy (>=1.5)"]
+test = ["flask", "jinja2", "matplotlib", "pytest-astropy", "pytest-dependency"]
+
+[[package]]
 name = "attrs"
 version = "23.1.0"
 description = "Classes Without Boilerplate"
@@ -72,6 +97,24 @@ dev = ["attrs[docs,tests]", "pre-commit"]
 docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
 tests = ["attrs[tests-no-zope]", "zope-interface"]
 tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.12.2"
+description = "Screen-scraping library"
+optional = false
+python-versions = ">=3.6.0"
+files = [
+    {file = "beautifulsoup4-4.12.2-py3-none-any.whl", hash = "sha256:bd2520ca0d9d7d12694a53d44ac482d181b4ec1888909b035a3dbf40d0f57d4a"},
+    {file = "beautifulsoup4-4.12.2.tar.gz", hash = "sha256:492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da"},
+]
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
 
 [[package]]
 name = "black"
@@ -330,6 +373,51 @@ files = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "41.0.5"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cryptography-41.0.5-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:da6a0ff8f1016ccc7477e6339e1d50ce5f59b88905585f77193ebd5068f1e797"},
+    {file = "cryptography-41.0.5-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b948e09fe5fb18517d99994184854ebd50b57248736fd4c720ad540560174ec5"},
+    {file = "cryptography-41.0.5-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d38e6031e113b7421db1de0c1b1f7739564a88f1684c6b89234fbf6c11b75147"},
+    {file = "cryptography-41.0.5-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e270c04f4d9b5671ebcc792b3ba5d4488bf7c42c3c241a3748e2599776f29696"},
+    {file = "cryptography-41.0.5-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ec3b055ff8f1dce8e6ef28f626e0972981475173d7973d63f271b29c8a2897da"},
+    {file = "cryptography-41.0.5-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7d208c21e47940369accfc9e85f0de7693d9a5d843c2509b3846b2db170dfd20"},
+    {file = "cryptography-41.0.5-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:8254962e6ba1f4d2090c44daf50a547cd5f0bf446dc658a8e5f8156cae0d8548"},
+    {file = "cryptography-41.0.5-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:a48e74dad1fb349f3dc1d449ed88e0017d792997a7ad2ec9587ed17405667e6d"},
+    {file = "cryptography-41.0.5-cp37-abi3-win32.whl", hash = "sha256:d3977f0e276f6f5bf245c403156673db103283266601405376f075c849a0b936"},
+    {file = "cryptography-41.0.5-cp37-abi3-win_amd64.whl", hash = "sha256:73801ac9736741f220e20435f84ecec75ed70eda90f781a148f1bad546963d81"},
+    {file = "cryptography-41.0.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3be3ca726e1572517d2bef99a818378bbcf7d7799d5372a46c79c29eb8d166c1"},
+    {file = "cryptography-41.0.5-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:e886098619d3815e0ad5790c973afeee2c0e6e04b4da90b88e6bd06e2a0b1b72"},
+    {file = "cryptography-41.0.5-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:573eb7128cbca75f9157dcde974781209463ce56b5804983e11a1c462f0f4e88"},
+    {file = "cryptography-41.0.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:0c327cac00f082013c7c9fb6c46b7cc9fa3c288ca702c74773968173bda421bf"},
+    {file = "cryptography-41.0.5-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:227ec057cd32a41c6651701abc0328135e472ed450f47c2766f23267b792a88e"},
+    {file = "cryptography-41.0.5-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:22892cc830d8b2c89ea60148227631bb96a7da0c1b722f2aac8824b1b7c0b6b8"},
+    {file = "cryptography-41.0.5-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:5a70187954ba7292c7876734183e810b728b4f3965fbe571421cb2434d279179"},
+    {file = "cryptography-41.0.5-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:88417bff20162f635f24f849ab182b092697922088b477a7abd6664ddd82291d"},
+    {file = "cryptography-41.0.5-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c707f7afd813478e2019ae32a7c49cd932dd60ab2d2a93e796f68236b7e1fbf1"},
+    {file = "cryptography-41.0.5-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:580afc7b7216deeb87a098ef0674d6ee34ab55993140838b14c9b83312b37b86"},
+    {file = "cryptography-41.0.5-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fba1e91467c65fe64a82c689dc6cf58151158993b13eb7a7f3f4b7f395636723"},
+    {file = "cryptography-41.0.5-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:0d2a6a598847c46e3e321a7aef8af1436f11c27f1254933746304ff014664d84"},
+    {file = "cryptography-41.0.5.tar.gz", hash = "sha256:392cb88b597247177172e02da6b7a63deeff1937fa6fec3bbf902ebd75d97ec7"},
+]
+
+[package.dependencies]
+cffi = ">=1.12"
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
+docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
+nox = ["nox"]
+pep8test = ["black", "check-sdist", "mypy", "ruff"]
+sdist = ["build"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test-randomorder = ["pytest-randomly"]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.1.3"
 description = "Backport of PEP 654 (exception groups)"
@@ -402,6 +490,27 @@ files = [
     {file = "hpack-4.0.0-py3-none-any.whl", hash = "sha256:84a076fad3dc9a9f8063ccb8041ef100867b1878b25ef0ee63847a5d53818a6c"},
     {file = "hpack-4.0.0.tar.gz", hash = "sha256:fc41de0c63e687ebffde81187a948221294896f6bdc0ae2312708df339430095"},
 ]
+
+[[package]]
+name = "html5lib"
+version = "1.1"
+description = "HTML parser based on the WHATWG HTML specification"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d"},
+    {file = "html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"},
+]
+
+[package.dependencies]
+six = ">=1.9"
+webencodings = "*"
+
+[package.extras]
+all = ["chardet (>=2.2)", "genshi", "lxml"]
+chardet = ["chardet (>=2.2)"]
+genshi = ["genshi"]
+lxml = ["lxml"]
 
 [[package]]
 name = "hypercorn"
@@ -482,6 +591,39 @@ files = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.3.0"
+description = "Utility functions for Python class constructs"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "jaraco.classes-3.3.0-py3-none-any.whl", hash = "sha256:10afa92b6743f25c0cf5f37c6bb6e18e2c5bb84a16527ccfc0040ea377e7aaeb"},
+    {file = "jaraco.classes-3.3.0.tar.gz", hash = "sha256:c063dd08e89217cee02c8d5e5ec560f2c8ce6cdc2fcdc2e68f7b2e5547ed3621"},
+]
+
+[package.dependencies]
+more-itertools = "*"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
+
+[[package]]
+name = "jeepney"
+version = "0.8.0"
+description = "Low-level, pure Python DBus protocol wrapper."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jeepney-0.8.0-py3-none-any.whl", hash = "sha256:c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755"},
+    {file = "jeepney-0.8.0.tar.gz", hash = "sha256:5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806"},
+]
+
+[package.extras]
+test = ["async-timeout", "pytest", "pytest-asyncio (>=0.17)", "pytest-trio", "testpath", "trio"]
+trio = ["async_generator", "trio"]
+
+[[package]]
 name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
@@ -497,6 +639,29 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "keyring"
+version = "24.2.0"
+description = "Store and access your passwords safely."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "keyring-24.2.0-py3-none-any.whl", hash = "sha256:4901caaf597bfd3bbd78c9a0c7c4c29fcd8310dab2cffefe749e916b6527acd6"},
+    {file = "keyring-24.2.0.tar.gz", hash = "sha256:ca0746a19ec421219f4d713f848fa297a661a8a8c1504867e55bfb5e09091509"},
+]
+
+[package.dependencies]
+importlib-metadata = {version = ">=4.11.4", markers = "python_version < \"3.12\""}
+"jaraco.classes" = "*"
+jeepney = {version = ">=0.4.2", markers = "sys_platform == \"linux\""}
+pywin32-ctypes = {version = ">=0.2.0", markers = "sys_platform == \"win32\""}
+SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
+
+[package.extras]
+completion = ["shtab"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
 [[package]]
 name = "markdown-it-py"
@@ -600,6 +765,17 @@ python-versions = ">=3.7"
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.1.0"
+description = "More routines for operating on iterables, beyond itertools"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "more-itertools-10.1.0.tar.gz", hash = "sha256:626c369fa0eb37bac0291bce8259b332fd59ac792fa5497b59837309cd5b114a"},
+    {file = "more_itertools-10.1.0-py3-none-any.whl", hash = "sha256:64e0735fcfdc6f3464ea133afe8ea4483b1c5fe3a3d69852e6503b43a0b222e6"},
 ]
 
 [[package]]
@@ -814,6 +990,37 @@ files = [
 plugins = ["importlib-metadata"]
 
 [[package]]
+name = "pyvo"
+version = "1.4.2"
+description = "Astropy affiliated package for accessing Virtual Observatory data and services"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyvo-1.4.2-py3-none-any.whl", hash = "sha256:74142901862b2c70b2eb0505355fe4ce4cf6907d290bb2a67b4f80c087b7a217"},
+    {file = "pyvo-1.4.2.tar.gz", hash = "sha256:66fe298865acfd725bc5f18750772d7f1b8899b8e5bb1775721520bed57d95cb"},
+]
+
+[package.dependencies]
+astropy = ">=4.1"
+requests = "*"
+
+[package.extras]
+all = ["pillow"]
+docs = ["sphinx-astropy"]
+test = ["pytest-astropy", "pytest-doctestplus (>=0.13)", "requests-mock"]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.2"
+description = "A (partial) reimplementation of pywin32 using ctypes/cffi"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pywin32-ctypes-0.2.2.tar.gz", hash = "sha256:3426e063bdd5fd4df74a14fa3cf80a0b42845a87e1d1e81f6549f9daec593a60"},
+    {file = "pywin32_ctypes-0.2.2-py3-none-any.whl", hash = "sha256:bf490a1a709baf35d688fe0ecf980ed4de11d2b3e37b51e5442587a75d9957e7"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -975,6 +1182,32 @@ files = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.3.3"
+description = "Python bindings to FreeDesktop.org Secret Service API"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99"},
+    {file = "SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77"},
+]
+
+[package.dependencies]
+cryptography = ">=2.0"
+jeepney = ">=0.6"
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.0"
 description = "Sniff out which async library your code is running under"
@@ -994,6 +1227,17 @@ python-versions = "*"
 files = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.5"
+description = "A modern CSS selector implementation for Beautiful Soup."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "soupsieve-2.5-py3-none-any.whl", hash = "sha256:eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7"},
+    {file = "soupsieve-2.5.tar.gz", hash = "sha256:5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690"},
 ]
 
 [[package]]
@@ -1056,6 +1300,17 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "webencodings"
+version = "0.5.1"
+description = "Character encoding aliases for legacy web content"
+optional = false
+python-versions = "*"
+files = [
+    {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
+    {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
+]
+
+[[package]]
 name = "werkzeug"
 version = "3.0.0"
 description = "The comprehensive WSGI web application library."
@@ -1104,4 +1359,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "9c0d10903a5b03134093f3993905e9732d82a2c90293c8c655cb199cb17e380f"
+content-hash = "0ee0a07237ec001b768942fca0ec59750fa224c1eced50fe43a0c876bcd3187a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ pyexiftool = "^0.5.5"
 quart = "^0.19.3"
 quart-trio = "^0.11.0"
 trio = "^0.22.2"
+astroquery = "^0.4.6"
+typing-extensions = "^4.8.0"
 
 [tool.poetry.group.rpi]
 optional = true

--- a/scripts/barnards.sh
+++ b/scripts/barnards.sh
@@ -1,11 +1,12 @@
 DIR=$(date +"%m-%d-%Y")
-NAME="cassiopeia"
+NAME="barnards-loop"
 
-FRAMES=150 # Number of frames to take
+FRAMES=1 # Number of frames to take
 FOCAL=30
-ISO=1600
-APERTURE=5.6
-EXPOSURE=60 # Exposure, in seconds 
+ISO=800
+APERTURE=5
+
+EXPOSURE=90 # Exposure, in seconds 
 
 # FOCAL_REDUCER="fr6.3-"
 # BARLOW=""
@@ -31,25 +32,27 @@ EXPOSURE=60 # Exposure, in seconds
 # ---------------
 # LIGHTS
 # ---------------
-for COUNT in `seq 1 $FRAMES`
-    do
-        echo ""
-        echo "${COUNT}/${FRAMES}"
-        echo ""
+# for COUNT in `seq 1 $FRAMES`
+#     do
+#         echo ""
+#         echo "${COUNT}/${FRAMES}"
+#         echo ""
 
-            # --hook-script=hist-hook.sh \
-        gphoto2 \
-            --set-config imageformat="7" \
-            --set-config-index picturestyle=6 \
-            --set-config shutterspeed=bulb \
-            --set-config iso=$ISO \
-            --set-config autoexposuremode=3 \
-            --filename "/home/pi/astrophotography/captures/$DIR/$NAME/ISO$ISO-${APERTURE}-bulb-${EXPOSURE}s-${FOCAL}-mm-%m-%d-%y_%H:%M:%S__${COUNT}.%C" \
-            --set-config eosremoterelease=5 \
-            --wait-event=${EXPOSURE}s \
-            --set-config eosremoterelease=11 \
-            --wait-event-and-download=6s
-    done
+
+#             # --hook-script=hist-hook.sh \
+
+#         gphoto2 \
+#             --set-config imageformat=6 \
+#             --set-config-index picturestyle=6 \
+#             --set-config shutterspeed=bulb \
+#             --set-config iso=$ISO \
+#             --set-config autoexposuremode=3 \
+#             --filename "/home/pi/astrophotography/captures/$DIR/$NAME/ISO$ISO-${APERTURE}-bulb-${EXPOSURE}s-${FOCAL}-mm-%m-%d-%y_%H:%M:%S__${COUNT}.%C" \
+#             --set-config eosremoterelease=5 \
+#             --wait-event=${EXPOSURE}s \
+#             --set-config eosremoterelease=11 \
+#             --wait-event-and-download=6s
+#     done
 
 # ---------------
 # DARKS
@@ -94,17 +97,17 @@ for COUNT in `seq 1 $FRAMES`
 # --set-config autoexposuremode=3 \ this is Manual
 
     # --hook-script=hist-hook.sh \
-# gphoto2 \
-#     --set-config imageformat=7 \
-#     --set-config-index picturestyle=1 \
-#     --set-config autoexposuremode=2 \
-#     --set-config aperture=36 \
-#     --set-config iso=$ISO \
-#     --set-config shutterspeed="1/4000" \
-#     --interval 5 \
-#     --frames ${FRAMES} \
-#     --filename "/home/pi/astrophotography/captures/$DIR/$NAME/flats-ISO$ISO-${APERTURE}-bulb-${EXPOSURE}s-${FOCAL}-mm-%m-%d-%y_%H:%M:%S.%C" \
-#     --capture-image-and-download
+gphoto2 \
+    --set-config imageformat=7 \
+    --set-config-index picturestyle=1 \
+    --set-config autoexposuremode=2 \
+    --set-config aperture=36 \
+    --set-config iso=$ISO \
+    --set-config shutterspeed="1/4000" \
+    --interval 5 \
+    --frames ${FRAMES} \
+    --filename "/home/pi/astrophotography/captures/$DIR/$NAME/flats-ISO$ISO-${APERTURE}-bulb-${EXPOSURE}s-${FOCAL}-mm-%m-%d-%y_%H:%M:%S.%C" \
+    --capture-image-and-download
 
 # Choice: 10 18
 # Choice: 11 20

--- a/scripts/hist-hook.sh
+++ b/scripts/hist-hook.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ $ARGUMENT ]; then
+    if [[ $ARGUMENT =~ .+\.[jpg|JPG] ]]
+    then
+    DIRNAME=$(dirname "$ARGUMENT")
+    BASENAME=$(basename "$ARGUMENT")
+    NEWFILENAME="$DIRNAME/$BASENAME"
+
+    # echo ""
+    # echo "--------------------------------------"
+    # echo "DIRNAME: $DIRNAME"
+    # echo "BASENAME: $BASENAME"
+    # echo "NEWFILENAME: $NEWFILENAME"
+    # echo "--------------------------------------"
+    # echo ""
+
+    . /home/pi/astrophotography/scripts/histogram.sh $NEWFILENAME
+    fi
+fi

--- a/scripts/histogram.sh
+++ b/scripts/histogram.sh
@@ -1,0 +1,7 @@
+echo ""
+echo "Converting to Histogram:"
+echo $1
+echo ""
+
+convert $1 histogram:- | convert - ${1%.*}-hist.jpg
+echo "Histogram saved: ${1%.*}.jpg"

--- a/src/activity.py
+++ b/src/activity.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from enum import Enum, auto
+from types import TracebackType
+from typing import Callable, Protocol, TypeVar
+
+
+_T = TypeVar("_T")
+
+
+class Activity:
+    _status: ActivityStatus
+    _cond: _Condition
+    _canceled: bool
+
+    def __init__(self, cond: _Condition):
+        self._status = ActivityStatus.PENDING
+        self._cond = cond
+        self._canceled = False
+
+    def wait_for(
+        self,
+        pred: Callable[[ActivityStatus], _T],
+        timeout: float | None = None,
+    ) -> _T:
+        with self._cond:
+            return self._cond.wait_for(lambda: pred(self._status), timeout)
+
+    def cancel(self):
+        with self._cond:
+            self._canceled = True
+            self._cond.notify_all()
+
+    def __repr__(self):
+        return f"Activity({self._status.name})"
+
+
+class ActivityStatus(Enum):
+    PENDING = auto()
+
+    ACTIVE = auto()
+    COMPLETE = auto()
+
+    ABORTING = auto()
+    ABORTED = auto()
+
+    def running(self):
+        return self in [ActivityStatus.ACTIVE, ActivityStatus.ABORTING]
+
+    def done(self):
+        return self in [ActivityStatus.COMPLETE, ActivityStatus.ABORTED]
+
+
+class _Condition(Protocol):
+    def __enter__(self) -> bool:
+        ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+        /,
+    ) -> None:
+        ...
+
+    def wait_for(self, predicate: Callable[[], _T], timeout: float | None = ...) -> _T:
+        ...
+
+    def notify_all(self) -> None:
+        ...

--- a/src/api/camera.py
+++ b/src/api/camera.py
@@ -1,8 +1,8 @@
-from ._blueprint import api
 from quart import request
-from gphoto2.gphoto import GPhoto
 
-from api.response import returnResponse
+from ..gphoto2.gphoto import GPhoto
+from ._blueprint import api
+from .response import returnResponse
 
 Cam = GPhoto()
 

--- a/src/api/capture.py
+++ b/src/api/capture.py
@@ -1,8 +1,9 @@
 from quart import request
-from ._blueprint import api
 import trio
-from gphoto2.gphoto import GPhoto
-from api.response import returnResponse
+
+from ..gphoto2.gphoto import GPhoto
+from ._blueprint import api
+from .response import returnResponse
 
 scope: trio.CancelScope | None = None
 

--- a/src/api/telescope.py
+++ b/src/api/telescope.py
@@ -114,6 +114,18 @@ async def goto_by_name():
         return await returnResponse({"goto": False, "name": _name}, 400)
 
 
+@api.route("/goto/mpc/", methods=["POST"])
+async def goto_by_mpc_query():
+    try:
+        name = request.args.get("name")
+        assert name is not None
+        get_telescope().track(tc.MPCQueryTarget(name))
+
+        return await returnResponse({"goto": True, "name": name}, 200)
+    except:
+        return await returnResponse({"goto": False}, 400)
+
+
 @api.route("/goto/solar_system_object/", methods=["POST"])
 async def goto_solar_system_object():
     try:

--- a/src/api/telescope.py
+++ b/src/api/telescope.py
@@ -3,9 +3,9 @@ from quart import current_app, request
 from astropy.coordinates import ICRS, SkyCoord
 from astropy.time import Time
 
+from .. import telescope_control as tc
 from ._blueprint import api
 from .response import returnResponse
-import telescope_control as tc
 
 # TODO: Update the API to get things from telescope.config (and rebuild the
 # config, stop the telescope, restart the telescope as needed).

--- a/src/api/telescope.py
+++ b/src/api/telescope.py
@@ -45,6 +45,26 @@ async def calibrate_by_name():
         return await returnResponse({"calibrated": False, "name": _name}, 400)
 
 
+@api.route("/calibrate/bump/", methods=["POST"])
+async def calibrate_bump():
+    try:
+        bearing = int(request.args.get("bearing", "0"))
+        dec = int(request.args.get("dec", "0"))
+        sync = _bool_type(True)(request.args.get("sync", "true"))
+
+        telescope = get_telescope()
+        telescope.calibrate_rel_steps(bearing, dec)
+        target = telescope.target
+        if sync and target is not None:
+            telescope.track(target)
+
+        return await returnResponse(
+            {"calibrated": True, "bearing": bearing, "dec": dec}, 200
+        )
+    except:
+        return await returnResponse({"calibrated": False}, 400)
+
+
 @api.route("/calibrate/solar_system_object/", methods=["POST"])
 async def calibrate_solar_system_object():
     try:
@@ -75,7 +95,7 @@ async def goto():
         _ra = request.args.get("ra")
         _dec = request.args.get("dec")
 
-        get_telescope().target = tc.FixedTarget(SkyCoord(ra=_ra, dec=_dec, frame=ICRS))
+        get_telescope().track(tc.FixedTarget(SkyCoord(ra=_ra, dec=_dec, frame=ICRS)))
 
         return await returnResponse({"goto": True, "ra": _ra, "dec": _dec}, 200)
 
@@ -87,7 +107,7 @@ async def goto():
 async def goto_by_name():
     try:
         _name = request.args.get("name")
-        get_telescope().target = tc.FixedTarget(SkyCoord.from_name(_name))
+        get_telescope().track(tc.FixedTarget(SkyCoord.from_name(_name)))
 
         return await returnResponse({"goto": True, "name": _name}, 200)
     except:
@@ -98,7 +118,7 @@ async def goto_by_name():
 async def goto_solar_system_object():
     try:
         _name = request.args.get("name")
-        get_telescope().target = tc.SolarSystemTarget(_name)
+        get_telescope().track(tc.SolarSystemTarget(_name))
         return await returnResponse(
             {
                 "goto": True,
@@ -114,3 +134,18 @@ async def goto_solar_system_object():
             },
             400,
         )
+
+
+def _bool_type(bare_value: bool):
+    def parse(s: str) -> bool:
+        match s:
+            case "":
+                return bare_value
+            case "true":
+                return True
+            case "false":
+                return False
+            case _:
+                raise ValueError(f"{s!r} is not a valid boolean value")
+
+    return parse

--- a/src/appserver.py
+++ b/src/appserver.py
@@ -1,8 +1,8 @@
 from quart_trio import QuartTrio
 
-from api import api
-from api.telescope import KEY_TELESCOPE
-from telescope_control import TelescopeControl
+from .api import api
+from .api.telescope import KEY_TELESCOPE
+from .telescope_control import TelescopeControl
 
 
 def create_app(telescope: TelescopeControl):

--- a/src/gphoto2/gphoto.py
+++ b/src/gphoto2/gphoto.py
@@ -2,8 +2,13 @@ import requests
 from datetime import date
 
 from exiftool import ExifToolHelper
-from gphoto2.util import getCurrentConfigValueFromCamera, setConfigValueOnCamera, getAllConfigFromCamera, setMultipleValuesOnCamera
-from gphoto2.canon550d import FocalLengths
+from .util import (
+    getCurrentConfigValueFromCamera,
+    setConfigValueOnCamera,
+    getAllConfigFromCamera,
+    setMultipleValuesOnCamera,
+)
+from .canon550d import FocalLengths
 
 WEATHER_API_URL = 'http://wttr.in?format="%t+%w+%m+%M+%P+%z+%h+%C"'
 

--- a/src/lib/pi/motor.py
+++ b/src/lib/pi/motor.py
@@ -1,7 +1,7 @@
 import RPi.GPIO as GPIO
 
-import lib.pi.gpio as gpio
-from lib.nsleep import nsleep
+from . import gpio
+from ..nsleep import nsleep
 
 RA_PINS = dict(
     dir=gpio.RA_DIRECTION_PIN,

--- a/src/lib/stellarium.py
+++ b/src/lib/stellarium.py
@@ -7,7 +7,7 @@ from astropy.coordinates import ICRS, SkyCoord
 import astropy.units as u
 import trio
 
-import telescope_control as tc
+from .. import telescope_control as tc
 
 _log = logging.getLogger(__name__)
 

--- a/src/lib/stellarium.py
+++ b/src/lib/stellarium.py
@@ -123,6 +123,6 @@ async def _read_target(stream: trio.SocketStream, telescope: tc.TelescopeControl
     )
 
     _log.info(f"target: {coord}")
-    telescope.target = tc.FixedTarget(coord)
+    telescope.track(tc.FixedTarget(coord))
 
     return True

--- a/src/logging.json
+++ b/src/logging.json
@@ -28,7 +28,14 @@
       ],
       "propagate": false
     },
-    "telescope_control": {
+    "src.stepper": {
+      "level": "INFO",
+      "handlers": [
+        "stderr"
+      ],
+      "propagate": false
+    },
+    "src.telescope_control": {
       "level": "INFO",
       "handlers": [
         "stderr"

--- a/src/main.py
+++ b/src/main.py
@@ -69,7 +69,7 @@ async def main():
                 gear_ratio=4 * 4 * 4 * 4,
                 config=StepperConfig(
                     min_sleep_ns=50_000,
-                    max_speed=2000,
+                    max_speed=500,
                     max_accel=200,
                     max_decel=200,
                     pulse=bearing_pulse,
@@ -80,7 +80,7 @@ async def main():
                 gear_ratio=4 * 4,
                 config=StepperConfig(
                     min_sleep_ns=50_000,
-                    max_speed=2000,
+                    max_speed=500,
                     max_accel=200,
                     max_decel=200,
                     pulse=dec_pulse,

--- a/src/main.py
+++ b/src/main.py
@@ -9,10 +9,10 @@ from astropy.time import Time
 import astropy.units as u
 import trio
 
-import appserver
-import lib.stellarium as stellarium
-from lib.nsleep import nsleep
-import telescope_control as tc
+from .lib import stellarium
+from .lib.nsleep import nsleep
+from . import appserver
+from . import telescope_control as tc
 
 _log = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ async def main():
     args = parser.parse_args()
 
     if not args.virtual:
-        import lib.pi.gpio as gpio
+        from .lib.pi import gpio
 
         gpio.setup()
 

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import argparse
 import logging
 import logging.config
 import os
+import signal
 
 from astropy.coordinates import EarthLocation, HADec, SkyCoord
 from astropy.time import Time
@@ -93,6 +94,8 @@ async def main():
 
     try:
         async with trio.open_nursery() as n:
+            signal.signal(signal.SIGTERM, lambda sig, frame: n.cancel_scope.cancel())
+
             n.start_soon(telescope.run)
             n.start_soon(stellarium.serve, "0.0.0.0", 10001, telescope)
             n.start_soon(app.run_task, "0.0.0.0", 8765)

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ import trio
 
 from .lib import stellarium
 from .lib.nsleep import nsleep
+from .stepper import StepDir, Stepper, StepperConfig
 from . import appserver
 from . import telescope_control as tc
 
@@ -49,45 +50,43 @@ async def main():
 
     args = parser.parse_args()
 
-    if not args.virtual:
-        from .lib.pi import gpio
+    if args.virtual:
+        bearing_pulse = virtual_pulse("bearing")
+        dec_pulse = virtual_pulse("dec")
+    else:
+        from .lib.pi import gpio, motor
 
         gpio.setup()
+
+        bearing_pulse = rpi_pulse(motor.RA_PINS)
+        dec_pulse = rpi_pulse(motor.DEC_PINS)
 
     telescope = tc.TelescopeControl(
         config=tc.Config(
             bearing_axis=tc.StepperAxis(
                 motor_steps=800,
                 gear_ratio=4 * 4 * 4 * 4,
-                max_speed=1.5 * u.deg / u.second,  # pyright: ignore
+                config=StepperConfig(
+                    min_sleep_ns=50_000,
+                    max_speed=2000,
+                    max_accel=200,
+                    max_decel=200,
+                    pulse=bearing_pulse,
+                ),
             ),
             declination_axis=tc.StepperAxis(
                 motor_steps=400,
                 gear_ratio=4 * 4,
-                max_speed=4 * u.deg / u.second,  # pyright: ignore
-            ),
-            motor_controller=(
-                noop_motor_controller if args.virtual else rpi_motor_controller
+                config=StepperConfig(
+                    min_sleep_ns=50_000,
+                    max_speed=2000,
+                    max_accel=200,
+                    max_decel=200,
+                    pulse=dec_pulse,
+                ),
             ),
             location=STEPHEN_HOUSE,
         ),
-        orientation=(
-            0 * u.hourangle,  # pyright: ignore
-            0 * u.deg,  # pyright: ignore
-        ),
-        # orientation=orientation_from_skycoord(SkyCoord.from_name("Polaris")),
-        # orientation=orientation_from_skycoord(SkyCoord.from_name("Mebsuta")),
-        # target=tc.FixedTarget(
-        #     SkyCoord(
-        #         0 * u.hourangle,  # pyright: ignore
-        #         0 * u.deg,  # pyright: ignore
-        #         frame=HADec(obstime=Time.now(), location=STEPHEN_HOUSE),
-        #     ).transform_to(ICRS)
-        # ),
-        # target=tc.FixedTarget(SkyCoord.from_name("Mebsuta")),
-        # target=tc.FixedTarget(SkyCoord.from_name("Polaris")),
-        # target=tc.FixedTarget(SkyCoord.from_name("Vega")),
-        # target=tc.SolarSystemTarget("jupiter"),
     )
 
     app = appserver.create_app(telescope)
@@ -101,57 +100,24 @@ async def main():
         pass
 
 
-def noop_motor_controller(
-    config: tc.Config,
-    axes: list[tc.StepperAxis],
-    actions: list[int],
-):
-    for axis, action in zip(axes, actions):
-        name = "unknown"
-        if axis is config.bearing_axis:
-            name = "bearing"
-        elif axis is config.declination_axis:
-            name = "dec"
+def virtual_pulse(name: str):
+    def pulse(stepper: Stepper, direction: StepDir):
+        _log.debug(f"pulse {name}: {direction}")
 
-        if action != 0:
-            _log.debug(f"pulse {name}: {action}")
+    return pulse
 
 
-def rpi_motor_controller(
-    config: tc.Config,
-    axes: list[tc.StepperAxis],
-    actions: list[int],
-):
-    import lib.pi.motor as motor
+def rpi_pulse(pins, fwd=1, rev=0):
+    from .lib.pi import motor
 
-    def find_pins(axis: tc.StepperAxis):
-        if axis is config.bearing_axis:
-            return motor.RA_PINS, 1, 0
-        elif axis is config.declination_axis:
-            return motor.DEC_PINS, 0, 1
-        else:
-            _log.error(f"unknown axis: {axis}")
-            return None
+    def pulse(stepper: Stepper, direction: StepDir):
+        match direction:
+            case StepDir.FWD:
+                motor.step(pins, fwd)
+            case StepDir.REV:
+                motor.step(pins, rev)
 
-    resolved_actions = [
-        (find_pins(axis), action) for axis, action in zip(axes, actions)
-    ]
-    for [pins, fwd, rev], action in resolved_actions:
-        if pins is None:
-            continue
-
-        if action == 1:
-            motor.leading(pins, fwd)  # forward
-        elif action == -1:
-            motor.leading(pins, rev)  # backward
-
-    nsleep(motor.PULSE_NS)
-
-    for [pins, _, _], _ in resolved_actions:
-        if pins is None:
-            continue
-
-        motor.trailing(pins)
+    return pulse
 
 
 if __name__ == "__main__":

--- a/src/motion.py
+++ b/src/motion.py
@@ -102,8 +102,13 @@ def pulse_times_linaccel(
     u: float,  # initial velocity
     a: float,  # accelration
 ):
+    if steps == 0:
+        return np.array([])
+
     s = np.linspace(math.copysign(1, steps), steps, abs(steps))
-    common = np.sqrt(2 * a * s + u**2)
+    # TODO: I'm not wild about this np.clip, but I'm getting nan for the final
+    # value (but only sometimes, especially in Stepper _plan_abort).
+    common = np.sqrt(np.clip(2 * a * s + u**2, 0, None))
 
     # print(f"{num:10}{round(u, 2):10}{a:10}{round(common[0], 2):10}")
     # TODO: Prove that this is the right way to choose which root is correct.

--- a/src/motion.py
+++ b/src/motion.py
@@ -1,0 +1,161 @@
+import math
+import numpy as np
+
+
+def travel_linaccel(vi: float, vf: float, a: float):
+    return (vf**2 - vi**2) / (2 * a)
+
+
+def _trapz_intercept_cruise_velocity_roots(
+    c: float,  # max speed (abs)
+    a_in: float,  # in acceleration
+    a_out: float,  # out acceleration
+    p_i: float,  # initial position
+    v_i: float,  # initial velocity
+    v_f: float,  # final velocity
+    q_i: float,  # target initial position
+    u: float,  # target velocity
+):
+    if abs(u) >= c:
+        raise ValueError("max speed (c) smaller than target velocity")
+
+    root_interior = (
+        (a_in**2 - 2 * a_in * a_out + a_out**2) * u**2
+        - 2 * (a_in**2 - a_in * a_out) * u * v_f
+        + (a_in**2 - a_in * a_out) * v_f**2
+        + 2 * (a_in * a_out - a_out**2) * u * v_i
+        - (a_in * a_out - a_out**2) * v_i**2
+        + 2 * (a_in**2 * a_out - a_in * a_out**2) * p_i
+        - 2 * (a_in**2 * a_out - a_in * a_out**2) * q_i
+    )
+
+    # TODO: Check negative, reject
+
+    root_part = math.sqrt(root_interior)
+
+    root1 = ((a_in - a_out) * u - root_part) / (a_in - a_out)
+    if abs(root1) > c:
+        root1 = math.copysign(c, root1)
+
+    root2 = ((a_in - a_out) * u + root_part) / (a_in - a_out)
+    if abs(root2) > c:
+        root2 = math.copysign(c, root2)
+    return root1, root2
+
+
+def _trapz_intercept_time(
+    a_in: float,  # in acceleration
+    a_out: float,  # out acceleration
+    p_i: float,  # initial position
+    v_i: float,  # initial velocity
+    v_f: float,  # final velocity
+    q_i: float,  # target initial position
+    u: float,  # target velocity
+    v_c: float,  # cruise velocity
+):
+    return (
+        1
+        / 2
+        * (
+            2 * a_in * a_out * p_i
+            - 2 * a_in * a_out * q_i
+            + (a_in - a_out) * v_c**2
+            - 2 * a_in * v_c * v_f
+            + a_in * v_f**2
+            + 2 * a_out * v_c * v_i
+            - a_out * v_i**2
+        )
+        / (a_in * a_out * u - a_in * a_out * v_c)
+    )
+
+
+def trapz_intercept_info(
+    c: float,  # max speed (abs)
+    a_in: float,  # in acceleration
+    a_out: float,  # out acceleration
+    p_i: float,  # initial position
+    v_i: float,  # initial velocity
+    v_f: float,  # final velocity
+    q_i: float,  # target initial position
+    u: float,  # target velocity
+):
+    v_c_1, v_c_2 = _trapz_intercept_cruise_velocity_roots(
+        c, a_in, a_out, p_i, v_i, v_f, q_i, u
+    )
+    t = _trapz_intercept_time(a_in, a_out, p_i, v_i, v_f, q_i, u, v_c_2)
+    v_c = v_c_2
+    if t < 0:
+        t_alt = _trapz_intercept_time(a_in, a_out, p_i, v_i, v_f, q_i, u, v_c_1)
+        raise Exception(
+            f"maybe it's the other root sometimes, after all: {t} - {t_alt}"
+        )
+
+    return dict(
+        v_c=v_c,
+        t=t,
+        p_f=q_i + t * u,
+    )
+
+
+def pulse_times_linaccel(
+    steps: int,  # signed step count
+    u: float,  # initial velocity
+    a: float,  # accelration
+):
+    s = np.linspace(math.copysign(1, steps), steps, abs(steps))
+    common = np.sqrt(2 * a * s + u**2)
+
+    # print(f"{num:10}{round(u, 2):10}{a:10}{round(common[0], 2):10}")
+    # TODO: Prove that this is the right way to choose which root is correct.
+    if math.copysign(steps, common[0]) == steps:
+        return -(u - common) / a
+    else:
+        return -(u + common) / a
+
+
+def pulse_times_constant(
+    steps: int,  # signed step count
+    v: float,  # velocity
+):
+    s = np.linspace(math.copysign(1, steps), steps, abs(steps))
+    return s / v
+
+
+def _discretize_trapz_accel(s_in: float, s_out: float, steps: int):
+    steps_in = int(np.trunc(s_in))
+    steps_out = int(np.trunc(s_out))
+
+    assert abs(steps_in + steps_out) <= abs(steps)
+    steps_cruise = steps - (steps_in + steps_out)
+    return steps_in, steps_cruise, steps_out
+
+
+def pulse_times_trapz(
+    v_i: float,  # initial velocity
+    v_f: float,  # final velocity
+    v_c: float,  # cruise velocity
+    a_in: float,  # in acceleration
+    a_out: float,  # out acceleration
+    steps: int,  # signed step count
+):
+    s_in = travel_linaccel(v_i, v_c, a_in)
+    s_out = travel_linaccel(v_c, v_f, a_out)
+
+    # OPT: Could preallocate an array of `steps` floats, and then fill it,
+    # instead of using `np.concatenate`.
+
+    steps_in, steps_c, steps_out = _discretize_trapz_accel(s_in, s_out, steps)
+
+    t_max = 0
+    t_in = pulse_times_linaccel(steps_in, v_i, a_in)
+
+    if steps_in != 0:
+        t_max = t_in[-1]
+
+    t_cruise = t_max + pulse_times_constant(steps_c, v_c)
+    if steps_c != 0:
+        t_max = t_cruise[-1]
+
+    t_out = t_max + pulse_times_linaccel(steps_out, v_c, a_out)
+
+    return np.concatenate([t_in, t_cruise, t_out])

--- a/src/stepper.py
+++ b/src/stepper.py
@@ -42,7 +42,7 @@ class StepperConfig:
     max_accel: float  # steps/s/s
     max_decel: float  # steps/s/s
     pulse: _PulseFn
-    max_interval_ns: int = 50_000_000
+    max_interval_ns: int = 250_000_000
 
 
 class StepDir(IntEnum):

--- a/src/stepper.py
+++ b/src/stepper.py
@@ -1,0 +1,469 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from enum import Enum, IntEnum, auto
+import math
+from queue import Queue
+from threading import Condition, Lock, Thread
+import time
+from typing import Callable, Protocol, TypeAlias, TypeVar
+from typing_extensions import assert_never
+
+import numpy as np
+
+from .lib.nsleep import nsleep
+from .motion import pulse_times_trapz, travel_linaccel, trapz_intercept_info
+
+_log = logging.Logger(__name__)
+
+
+@dataclass(frozen=True)
+class StepperConfig:
+    min_sleep_ns: int
+    max_speed: float  # steps/s
+    max_accel: float  # steps/s/s
+    max_decel: float  # steps/s/s
+
+
+class _Direction(IntEnum):
+    FWD = 1
+    NOP = 0
+    REV = -1
+
+
+class ActivityStatus(Enum):
+    PENDING = auto()
+
+    ACTIVE = auto()
+    COMPLETE = auto()
+
+    ABORTING = auto()
+    ABORTED = auto()
+
+    def running(self):
+        return self in [ActivityStatus.ACTIVE, ActivityStatus.ABORTING]
+
+    def done(self):
+        return self in [ActivityStatus.COMPLETE, ActivityStatus.ABORTED]
+
+
+@dataclass
+class _Intercept:
+    target: int
+    target_velocity: float
+    final_velocity: float
+
+
+@dataclass
+class _RunConstant:
+    velocity: float
+    deadline_ns: int
+
+
+# TODO: Rename to _Noop?  Maybe it could be eliminated?
+@dataclass
+class _Idle:
+    pass
+
+
+@dataclass
+class _Stop:
+    pass
+
+
+_Goal: TypeAlias = _Intercept | _RunConstant | _Idle | _Stop
+
+
+_T = TypeVar("_T")
+
+
+class Activity:
+    _goal: _Goal
+    _status: ActivityStatus
+    _cond: Condition
+    _canceled: bool
+
+    def __init__(self, goal: _Goal, cond: Condition):
+        self._goal = goal
+        self._status = ActivityStatus.PENDING
+        self._cond = cond
+        self._canceled = False
+
+    def wait_for(
+        self, pred: Callable[[ActivityStatus], _T], timeout: float | None = None
+    ) -> _T:
+        with self._cond:
+            return self._cond.wait_for(lambda: pred(self._status), timeout)
+
+    def cancel(self):
+        with self._cond:
+            self._canceled = True
+            self._cond.notify_all()
+
+    def __repr__(self):
+        return f"Activity({self._goal!r}, {self._status.name})"
+
+
+_MotionQueue: TypeAlias = Queue[tuple[int, _Direction] | Activity]
+
+
+@dataclass
+class _RunState:
+    plan_thread: Thread
+    run_thread: Thread
+
+
+@dataclass
+class _PlanContext:
+    commit_pos: int
+    commit_vel: float
+    commit_deadline: int
+
+
+class StateFn(Protocol):
+    def __call__(
+        self, stepper: Stepper, motion: _MotionQueue, ctx: _PlanContext
+    ) -> StateFn | None:
+        ...
+
+
+class Stepper:
+    _config: StepperConfig
+    _position: int
+    _velocity: float
+
+    _lock: Lock
+    _run_state: _RunState | None
+    _activities: Queue[Activity]
+    _activity_fallback_cond: Condition
+
+    def __init__(
+        self,
+        config: StepperConfig,
+        position: int = 0,
+        velocity: float = 0,
+    ):
+        self._config = config
+        self._position = position
+        self._velocity = velocity
+
+        self._lock = Lock()
+        self._run_state = None
+        self._activities = Queue()
+        self._activity_fallback_cond = Condition()
+
+    @property
+    def position(self):
+        with self._lock:
+            return self._position
+
+    def goto(
+        self,
+        target: int,
+        final_velocity: float = 0,
+        cond: Condition | None = None,
+    ):
+        return self._put_activity(_Intercept(target, 0, final_velocity), cond)
+
+    def idle(self, cond: Condition | None = None):
+        return self._put_activity(_Idle(), cond)
+
+    def intercept(
+        self,
+        target: int,
+        target_velocity: float,
+        final_velocity: float | None = None,
+        cond: Condition | None = None,
+    ):
+        if final_velocity is None:
+            final_velocity = target_velocity
+        return self._put_activity(
+            _Intercept(target, target_velocity, final_velocity), cond
+        )
+
+    def run_constant(
+        self,
+        velocity: float,
+        deadline_ns: int,
+        cond: Condition | None = None,
+    ):
+        return self._put_activity(_RunConstant(velocity, deadline_ns), cond)
+
+    def _put_activity(self, goal: _Goal, cond: Condition | None) -> Activity:
+        activity = Activity(goal, cond or self._activity_fallback_cond)
+        self._activities.put(activity)
+        return activity
+
+    def start(self):
+        with self._lock:
+            if self._run_state is not None:
+                return
+
+            # TODO: Make plan ahead steps configurable
+            motion: _MotionQueue = Queue(maxsize=10)
+
+            run_state = _RunState(
+                plan_thread=Thread(target=self._plan, args=[motion]),
+                run_thread=Thread(target=self._move, args=[motion]),
+            )
+            self._run_state = run_state
+
+            for t in [run_state.plan_thread, run_state.run_thread]:
+                t.start()
+
+    # TODO: Should start/stop take a Condition and return an Activity?
+    def stop(self, timeout: float | None = None):
+        deadline = None
+        if timeout is not None:
+            deadline = time.time() + timeout
+
+        with self._lock:
+            run_state = self._run_state
+            if run_state is None:
+                return
+
+        self._put_activity(_Stop(), None).wait_for(ActivityStatus.done)
+
+        for t in [run_state.plan_thread, run_state.run_thread]:
+            t.join(deadline - time.time() if deadline is not None else None)
+
+        with self._lock:
+            self._run_state = None
+
+    def _plan(self, motion: _MotionQueue):
+        with self._lock:
+            ctx = _PlanContext(
+                self._position,
+                self._velocity,
+                time.time_ns(),
+            )
+
+        statefn = _plan_dispatch
+        while statefn is not None:
+            statefn = statefn(self, motion, ctx)
+
+    def _move(self, motion: _MotionQueue):
+        while True:
+            item = motion.get()
+            if isinstance(item, Activity):
+                with item._cond:
+                    match item._status:
+                        case ActivityStatus.ABORTING:
+                            item._status = ActivityStatus.ABORTED
+                        case ActivityStatus.ACTIVE:
+                            item._status = ActivityStatus.COMPLETE
+                        case _:
+                            assert (
+                                False
+                            ), f"unexpected Activity status: {item._status} on {item._goal}"
+
+                    item._cond.notify_all()
+
+                motion.task_done()
+                if isinstance(item._goal, _Stop):
+                    return
+                continue
+
+            try:
+                deadline, d = item
+                now = time.time_ns()
+
+                sleep_ns = deadline - now
+                if sleep_ns < self._config.min_sleep_ns:
+                    # FIXME: Better telemetry
+                    _log.warn(f"running behind: {sleep_ns}")
+                    deadline = now + self._config.min_sleep_ns
+
+                nsleep(sleep_ns)
+
+                with self._lock:
+                    if d != _Direction.NOP:
+                        # FIXME: Actually pulse the motor.
+                        pass
+                    self._position += d
+                    # FIXME: Calculate velocity
+                    self._velocity = 0
+            finally:
+                motion.task_done()
+
+
+def _plan_dispatch(stepper: Stepper, motion: _MotionQueue, ctx: _PlanContext):
+    activity = stepper._activities.get()
+    with activity._cond:
+        assert activity._status == ActivityStatus.PENDING
+
+    match activity._goal:
+        case _Idle() | _Stop() as g:
+            with activity._cond:
+                activity._status = ActivityStatus.ACTIVE
+                activity._cond.notify_all()
+            motion.put(activity)
+            if isinstance(g, _Stop):
+                return None
+            return _plan_dispatch
+        case _Intercept(_):
+            return _plan_intercept(activity)
+        case _RunConstant(_):
+            return _plan_run_constant(activity)
+        case _:
+            assert_never(activity._goal)
+
+
+def _plan_intercept(activity: Activity) -> StateFn:
+    assert isinstance(activity._goal, _Intercept)
+    goal = activity._goal
+
+    def plan_intercept(stepper: Stepper, motion: _MotionQueue, ctx: _PlanContext):
+        with activity._cond:
+            assert activity._status == ActivityStatus.PENDING
+
+            activity._status = ActivityStatus.ACTIVE
+            activity._cond.notify_all()
+
+        cfg = stepper._config
+
+        now = time.time_ns()
+        # TODO: Need to incorporate Config.min_sleep_ns?
+        start_ns = max(ctx.commit_deadline, now)
+        t0 = (start_ns - now) / 1_000_000_000
+        target_t0 = goal.target + t0 * goal.target_velocity
+
+        scratch_delta = target_t0 - ctx.commit_pos
+
+        a_in = math.copysign(cfg.max_accel, scratch_delta)
+        a_out = -math.copysign(cfg.max_decel, scratch_delta)
+
+        info = trapz_intercept_info(
+            cfg.max_speed,
+            a_in,
+            a_out,
+            ctx.commit_pos,
+            ctx.commit_vel,
+            goal.final_velocity,
+            target_t0,
+            goal.target_velocity,
+        )
+
+        delta = round(info["p_f"]) - ctx.commit_pos
+        if delta == 0:
+            motion.put(activity)
+            return _plan_dispatch
+
+        dir = _Direction.FWD if delta > 0 else _Direction.REV
+        deadlines = (
+            start_ns
+            + pulse_times_trapz(
+                ctx.commit_vel,
+                goal.final_velocity,
+                info["v_c"],
+                a_in,
+                a_out,
+                delta,
+            )
+            * 1_000_000_000
+        ).astype(np.int64)
+
+        velocities = np.empty_like(deadlines, dtype=np.float64)
+        velocities[0] = ctx.commit_vel
+        velocities[1:] = int(dir) * 1_000_000_000 / (deadlines[1:] - deadlines[:-1])
+
+        for deadline, velocity in zip(deadlines, velocities):
+            with activity._cond:
+                if activity._canceled:
+                    return _plan_abort(activity)
+
+            ctx.commit_deadline = deadline
+            ctx.commit_pos += dir
+            ctx.commit_vel = velocity
+            motion.put((deadline, dir))
+        else:
+            motion.put(activity)
+            return _plan_dispatch
+
+    return plan_intercept
+
+
+def _plan_run_constant(activity: Activity) -> StateFn:
+    assert isinstance(activity._goal, _RunConstant)
+    goal = activity._goal
+
+    def plan_run_constant(stepper: Stepper, motion: _MotionQueue, ctx: _PlanContext):
+        with activity._cond:
+            assert activity._status == ActivityStatus.PENDING
+            activity._status = ActivityStatus.ACTIVE
+            activity._cond.notify_all()
+
+        if goal.velocity == 0:
+            if ctx.commit_deadline < goal.deadline_ns:
+                motion.put((goal.deadline_ns, _Direction.NOP))
+            motion.put(activity)
+            return _plan_dispatch
+
+        # TODO: Deal with quantization errors (should be pretty small)
+        interval = abs(1_000_000_000 / goal.velocity)
+        dir = _Direction.FWD if goal.velocity > 0 else _Direction.REV
+
+        while True:
+            with activity._cond:
+                if activity._canceled:
+                    return _plan_abort(activity)
+
+            deadline = round(ctx.commit_deadline + interval)
+            if deadline > goal.deadline_ns:
+                if ctx.commit_deadline < goal.deadline_ns:
+                    motion.put((goal.deadline_ns, _Direction.NOP))
+                motion.put(activity)
+                return _plan_dispatch
+
+            ctx.commit_deadline = deadline
+            ctx.commit_pos += dir
+            ctx.commit_vel = goal.velocity
+            motion.put((deadline, dir))
+
+    return plan_run_constant
+
+
+def _plan_abort(activity: Activity) -> StateFn:
+    def plan_abort(stepper: Stepper, motion: _MotionQueue, ctx: _PlanContext):
+        with activity._cond:
+            activity._status = ActivityStatus.ABORTING
+            activity._cond.notify_all()
+
+        if ctx.commit_vel == 0 or ctx.commit_deadline is None:
+            return _plan_dispatch
+
+        dir = _Direction.FWD if ctx.commit_vel > 0 else _Direction.REV
+        steps = np.ceil(travel_linaccel(ctx.commit_vel, 0, -stepper._config.max_decel))
+        cfg = stepper._config
+        deadlines = (
+            ctx.commit_deadline
+            + pulse_times_trapz(
+                ctx.commit_vel,
+                0,
+                cfg.max_speed,
+                cfg.max_accel,
+                -cfg.max_decel,
+                steps,
+            )
+            * 1_000_000_000
+        ).astype(np.int64)
+
+        velocities = np.empty_like(deadlines, dtype=np.float64)
+        velocities[0] = ctx.commit_vel
+        velocities[1:] = (
+            (1 if dir == _Direction.FWD else -1)
+            * 1_000_000_000
+            / (deadlines[1:] - deadlines[:-1])
+        )
+
+        for deadline, velocity in zip(deadlines, velocities):
+            ctx.commit_deadline = deadline
+            ctx.commit_pos += dir
+            ctx.commit_vel = velocity
+            motion.put((deadline, dir))
+        else:
+            motion.put(activity)
+            return _plan_dispatch
+
+    return plan_abort

--- a/src/stepper.py
+++ b/src/stepper.py
@@ -446,6 +446,10 @@ def _plan_intercept(activity: _StepperActivity) -> _StateFn:
             * 1_000_000_000
         ).astype(np.int64)
 
+        if len(deadlines) == 0:
+            motion.put(activity)
+            return _plan_dispatch
+
         velocities = np.empty_like(deadlines, dtype=np.float64)
         velocities[0] = ctx.commit_vel
         velocities[1:] = int(dir) * 1_000_000_000 / (deadlines[1:] - deadlines[:-1])

--- a/src/stepper.py
+++ b/src/stepper.py
@@ -2,20 +2,37 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from enum import Enum, IntEnum, auto
+from enum import IntEnum
 import math
 from queue import Queue
 from threading import Condition, Lock, Thread
 import time
-from typing import Callable, Protocol, TypeAlias, TypeVar
+from typing import Protocol, TypeAlias
 from typing_extensions import assert_never
 
 import numpy as np
 
+from .activity import Activity as _Activity, ActivityStatus
 from .lib.nsleep import nsleep
-from .motion import pulse_times_trapz, travel_linaccel, trapz_intercept_info
+from .motion import (
+    pulse_times_linaccel,
+    pulse_times_trapz,
+    travel_linaccel,
+    trapz_intercept_info,
+)
 
-_log = logging.Logger(__name__)
+_log = logging.getLogger(__name__)
+
+# TODO: In Stepper, track an error term for desired fractional steps so abutting
+# activities with very slow movements can work perfectly.  Right now this gets
+# worked around in TelescopeControl by issuing very long run_constant commands
+# that guarantee a whole number of steps will occur.  This is inconvenient, and
+# it would be better if Stepper handled fractional moves itself.
+
+
+class _PulseFn(Protocol):
+    def __call__(self, /, stepper: Stepper, direction: StepDir) -> None:
+        ...
 
 
 @dataclass(frozen=True)
@@ -24,28 +41,25 @@ class StepperConfig:
     max_speed: float  # steps/s
     max_accel: float  # steps/s/s
     max_decel: float  # steps/s/s
+    pulse: _PulseFn
+    max_interval_ns: int = 50_000_000
 
 
-class _Direction(IntEnum):
+class StepDir(IntEnum):
     FWD = 1
     NOP = 0
     REV = -1
 
 
-class ActivityStatus(Enum):
-    PENDING = auto()
+class _StepperActivity(_Activity):
+    _goal: _Goal
 
-    ACTIVE = auto()
-    COMPLETE = auto()
+    def __init__(self, goal: _Goal, cond: Condition):
+        super().__init__(cond)
+        self._goal = goal
 
-    ABORTING = auto()
-    ABORTED = auto()
-
-    def running(self):
-        return self in [ActivityStatus.ACTIVE, ActivityStatus.ABORTING]
-
-    def done(self):
-        return self in [ActivityStatus.COMPLETE, ActivityStatus.ABORTED]
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._goal!r}, {self._status.name})"
 
 
 @dataclass
@@ -56,12 +70,19 @@ class _Intercept:
 
 
 @dataclass
+class _InterceptPrecomputed:
+    params: InterceptParams
+    start_ns: int
+
+
+@dataclass
 class _RunConstant:
     velocity: float
     deadline_ns: int
 
 
-# TODO: Rename to _Noop?  Maybe it could be eliminated?
+# TODO: Rename to _Noop?  Maybe it could be eliminated?  Maybe _Idle should spin
+# down to zero velocity, if needed?
 @dataclass
 class _Idle:
     pass
@@ -72,40 +93,10 @@ class _Stop:
     pass
 
 
-_Goal: TypeAlias = _Intercept | _RunConstant | _Idle | _Stop
+_Goal: TypeAlias = _InterceptPrecomputed | _Intercept | _RunConstant | _Idle | _Stop
 
 
-_T = TypeVar("_T")
-
-
-class Activity:
-    _goal: _Goal
-    _status: ActivityStatus
-    _cond: Condition
-    _canceled: bool
-
-    def __init__(self, goal: _Goal, cond: Condition):
-        self._goal = goal
-        self._status = ActivityStatus.PENDING
-        self._cond = cond
-        self._canceled = False
-
-    def wait_for(
-        self, pred: Callable[[ActivityStatus], _T], timeout: float | None = None
-    ) -> _T:
-        with self._cond:
-            return self._cond.wait_for(lambda: pred(self._status), timeout)
-
-    def cancel(self):
-        with self._cond:
-            self._canceled = True
-            self._cond.notify_all()
-
-    def __repr__(self):
-        return f"Activity({self._goal!r}, {self._status.name})"
-
-
-_MotionQueue: TypeAlias = Queue[tuple[int, _Direction] | Activity]
+_MotionQueue: TypeAlias = Queue[tuple[int, StepDir] | _StepperActivity]
 
 
 @dataclass
@@ -121,10 +112,10 @@ class _PlanContext:
     commit_deadline: int
 
 
-class StateFn(Protocol):
+class _StateFn(Protocol):
     def __call__(
         self, stepper: Stepper, motion: _MotionQueue, ctx: _PlanContext
-    ) -> StateFn | None:
+    ) -> _StateFn | None:
         ...
 
 
@@ -135,7 +126,7 @@ class Stepper:
 
     _lock: Lock
     _run_state: _RunState | None
-    _activities: Queue[Activity]
+    _activities: Queue[_StepperActivity]
     _activity_fallback_cond: Condition
 
     def __init__(
@@ -154,9 +145,18 @@ class Stepper:
         self._activity_fallback_cond = Condition()
 
     @property
+    def config(self):
+        return self._config
+
+    @property
     def position(self):
         with self._lock:
             return self._position
+
+    @property
+    def velocity(self):
+        with self._lock:
+            return self._velocity
 
     def goto(
         self,
@@ -168,6 +168,14 @@ class Stepper:
 
     def idle(self, cond: Condition | None = None):
         return self._put_activity(_Idle(), cond)
+
+    def intercept_precomputed(
+        self,
+        params: InterceptParams,
+        start_ns: int,
+        cond: Condition | None = None,
+    ):
+        return self._put_activity(_InterceptPrecomputed(params, start_ns), cond)
 
     def intercept(
         self,
@@ -190,8 +198,8 @@ class Stepper:
     ):
         return self._put_activity(_RunConstant(velocity, deadline_ns), cond)
 
-    def _put_activity(self, goal: _Goal, cond: Condition | None) -> Activity:
-        activity = Activity(goal, cond or self._activity_fallback_cond)
+    def _put_activity(self, goal: _Goal, cond: Condition | None) -> _Activity:
+        activity = _StepperActivity(goal, cond or self._activity_fallback_cond)
         self._activities.put(activity)
         return activity
 
@@ -201,7 +209,7 @@ class Stepper:
                 return
 
             # TODO: Make plan ahead steps configurable
-            motion: _MotionQueue = Queue(maxsize=10)
+            motion: _MotionQueue = Queue(maxsize=4)
 
             run_state = _RunState(
                 plan_thread=Thread(target=self._plan, args=[motion]),
@@ -239,14 +247,14 @@ class Stepper:
                 time.time_ns(),
             )
 
-        statefn = _plan_dispatch
+        statefn: _StateFn | None = _plan_dispatch
         while statefn is not None:
             statefn = statefn(self, motion, ctx)
 
     def _move(self, motion: _MotionQueue):
         while True:
             item = motion.get()
-            if isinstance(item, Activity):
+            if isinstance(item, _StepperActivity):
                 with item._cond:
                     match item._status:
                         case ActivityStatus.ABORTING:
@@ -254,9 +262,9 @@ class Stepper:
                         case ActivityStatus.ACTIVE:
                             item._status = ActivityStatus.COMPLETE
                         case _:
-                            assert (
-                                False
-                            ), f"unexpected Activity status: {item._status} on {item._goal}"
+                            raise RuntimeError(
+                                f"unexpected activity status: {item._status} on {item._goal}"
+                            )
 
                     item._cond.notify_all()
 
@@ -271,21 +279,88 @@ class Stepper:
 
                 sleep_ns = deadline - now
                 if sleep_ns < self._config.min_sleep_ns:
-                    # FIXME: Better telemetry
-                    _log.warn(f"running behind: {sleep_ns}")
-                    deadline = now + self._config.min_sleep_ns
+                    if d != StepDir.NOP:
+                        # FIXME: Better telemetry
+                        _log.warn(f"running behind: {sleep_ns / 1_000_000_000}")
+                    sleep_ns = self._config.min_sleep_ns
 
                 nsleep(sleep_ns)
 
+                if d != StepDir.NOP:
+                    self.config.pulse(self, d)
+
                 with self._lock:
-                    if d != _Direction.NOP:
-                        # FIXME: Actually pulse the motor.
-                        pass
                     self._position += d
                     # FIXME: Calculate velocity
                     self._velocity = 0
             finally:
                 motion.task_done()
+
+
+@dataclass(frozen=True)
+class InterceptParams:
+    # TODO: Capture inputs also?
+
+    delta: int
+    t: float
+    v_c: float
+    a_in: float
+    a_out: float
+    p_f: int
+    v_f: float
+
+
+def compute_intercept(
+    config: StepperConfig,
+    position: int,
+    velocity: float,
+    target: int,
+    target_velocity: float,
+    final_velocity: float,
+) -> InterceptParams:
+    # TODO: Does this need to be configurable?  Callers can easily do this
+    # calculation if they need to.
+    # t0 = 0
+    # target_t0 = target + t0 * target_velocity
+
+    scratch_delta = target - position
+
+    if scratch_delta == 0:
+        return InterceptParams(
+            delta=0,
+            t=0,
+            v_c=0,
+            a_in=0,
+            a_out=0,
+            p_f=position,
+            v_f=final_velocity,
+        )
+
+    a_in = math.copysign(config.max_accel, scratch_delta)
+    a_out = -math.copysign(config.max_decel, scratch_delta)
+
+    info = trapz_intercept_info(
+        config.max_speed,
+        a_in,
+        a_out,
+        position,
+        velocity,
+        final_velocity,
+        target,
+        target_velocity,
+    )
+
+    p_f = round(info["p_f"])
+    delta = round(info["p_f"]) - position
+    return InterceptParams(
+        delta=delta,
+        t=info["t"],
+        v_c=info["v_c"],
+        a_in=a_in,
+        a_out=a_out,
+        p_f=p_f,
+        v_f=final_velocity,
+    )
 
 
 def _plan_dispatch(stepper: Stepper, motion: _MotionQueue, ctx: _PlanContext):
@@ -302,16 +377,16 @@ def _plan_dispatch(stepper: Stepper, motion: _MotionQueue, ctx: _PlanContext):
             if isinstance(g, _Stop):
                 return None
             return _plan_dispatch
-        case _Intercept(_):
+        case _Intercept() | _InterceptPrecomputed():
             return _plan_intercept(activity)
-        case _RunConstant(_):
+        case _RunConstant():
             return _plan_run_constant(activity)
         case _:
             assert_never(activity._goal)
 
 
-def _plan_intercept(activity: Activity) -> StateFn:
-    assert isinstance(activity._goal, _Intercept)
+def _plan_intercept(activity: _StepperActivity) -> _StateFn:
+    assert isinstance(activity._goal, (_Intercept, _InterceptPrecomputed))
     goal = activity._goal
 
     def plan_intercept(stepper: Stepper, motion: _MotionQueue, ctx: _PlanContext):
@@ -321,45 +396,42 @@ def _plan_intercept(activity: Activity) -> StateFn:
             activity._status = ActivityStatus.ACTIVE
             activity._cond.notify_all()
 
-        cfg = stepper._config
-
         now = time.time_ns()
         # TODO: Need to incorporate Config.min_sleep_ns?
-        start_ns = max(ctx.commit_deadline, now)
-        t0 = (start_ns - now) / 1_000_000_000
-        target_t0 = goal.target + t0 * goal.target_velocity
+        ctx.commit_deadline = max(ctx.commit_deadline, now)
+        match goal:
+            case _InterceptPrecomputed(params, start_ns):
+                # Just extract params and start_ns
+                pass
+            case _Intercept():
+                start_ns = ctx.commit_deadline
 
-        scratch_delta = target_t0 - ctx.commit_pos
+                t0 = (start_ns - now) / 1_000_000_000
+                target_t0 = goal.target + t0 * goal.target_velocity
 
-        a_in = math.copysign(cfg.max_accel, scratch_delta)
-        a_out = -math.copysign(cfg.max_decel, scratch_delta)
+                params = compute_intercept(
+                    stepper._config,
+                    ctx.commit_pos,
+                    ctx.commit_vel,
+                    round(target_t0),
+                    goal.target_velocity,
+                    goal.final_velocity,
+                )
 
-        info = trapz_intercept_info(
-            cfg.max_speed,
-            a_in,
-            a_out,
-            ctx.commit_pos,
-            ctx.commit_vel,
-            goal.final_velocity,
-            target_t0,
-            goal.target_velocity,
-        )
-
-        delta = round(info["p_f"]) - ctx.commit_pos
-        if delta == 0:
+        if params.delta == 0:
             motion.put(activity)
             return _plan_dispatch
 
-        dir = _Direction.FWD if delta > 0 else _Direction.REV
+        dir = StepDir.FWD if params.delta > 0 else StepDir.REV
         deadlines = (
             start_ns
             + pulse_times_trapz(
                 ctx.commit_vel,
-                goal.final_velocity,
-                info["v_c"],
-                a_in,
-                a_out,
-                delta,
+                params.v_f,
+                params.v_c,
+                params.a_in,
+                params.a_out,
+                params.delta,
             )
             * 1_000_000_000
         ).astype(np.int64)
@@ -373,6 +445,16 @@ def _plan_intercept(activity: Activity) -> StateFn:
                 if activity._canceled:
                     return _plan_abort(activity)
 
+            for d in _nop_deadlines(
+                ctx.commit_deadline,
+                deadline,
+                stepper.config.max_interval_ns,
+            ):
+                with activity._cond:
+                    if activity._canceled:
+                        return _plan_abort(activity)
+                motion.put((d, StepDir.NOP))
+
             ctx.commit_deadline = deadline
             ctx.commit_pos += dir
             ctx.commit_vel = velocity
@@ -384,7 +466,7 @@ def _plan_intercept(activity: Activity) -> StateFn:
     return plan_intercept
 
 
-def _plan_run_constant(activity: Activity) -> StateFn:
+def _plan_run_constant(activity: _StepperActivity) -> _StateFn:
     assert isinstance(activity._goal, _RunConstant)
     goal = activity._goal
 
@@ -394,65 +476,82 @@ def _plan_run_constant(activity: Activity) -> StateFn:
             activity._status = ActivityStatus.ACTIVE
             activity._cond.notify_all()
 
+        ctx.commit_deadline = max(ctx.commit_deadline, time.time_ns())
+
         if goal.velocity == 0:
             if ctx.commit_deadline < goal.deadline_ns:
-                motion.put((goal.deadline_ns, _Direction.NOP))
+                ctx.commit_deadline = goal.deadline_ns
+                motion.put((goal.deadline_ns, StepDir.NOP))
             motion.put(activity)
             return _plan_dispatch
 
         # TODO: Deal with quantization errors (should be pretty small)
         interval = abs(1_000_000_000 / goal.velocity)
-        dir = _Direction.FWD if goal.velocity > 0 else _Direction.REV
+        dir = StepDir.FWD if goal.velocity > 0 else StepDir.REV
 
-        while True:
+        done = False
+        while not done:
             with activity._cond:
                 if activity._canceled:
                     return _plan_abort(activity)
 
             deadline = round(ctx.commit_deadline + interval)
             if deadline > goal.deadline_ns:
-                if ctx.commit_deadline < goal.deadline_ns:
-                    motion.put((goal.deadline_ns, _Direction.NOP))
-                motion.put(activity)
-                return _plan_dispatch
+                done = True
+                deadline = goal.deadline_ns
+
+            for d in _nop_deadlines(
+                ctx.commit_deadline,
+                deadline,
+                stepper.config.max_interval_ns,
+            ):
+                with activity._cond:
+                    if activity._canceled:
+                        return _plan_abort(activity)
+                motion.put((d, StepDir.NOP))
 
             ctx.commit_deadline = deadline
             ctx.commit_pos += dir
             ctx.commit_vel = goal.velocity
             motion.put((deadline, dir))
 
+        motion.put(activity)
+        return _plan_dispatch
+
     return plan_run_constant
 
 
-def _plan_abort(activity: Activity) -> StateFn:
+def _plan_abort(activity: _StepperActivity) -> _StateFn:
     def plan_abort(stepper: Stepper, motion: _MotionQueue, ctx: _PlanContext):
         with activity._cond:
             activity._status = ActivityStatus.ABORTING
             activity._cond.notify_all()
 
-        if ctx.commit_vel == 0 or ctx.commit_deadline is None:
+        ctx.commit_deadline = max(ctx.commit_deadline, time.time_ns())
+
+        if ctx.commit_vel == 0:
+            motion.put(activity)
             return _plan_dispatch
 
-        dir = _Direction.FWD if ctx.commit_vel > 0 else _Direction.REV
-        steps = np.ceil(travel_linaccel(ctx.commit_vel, 0, -stepper._config.max_decel))
         cfg = stepper._config
+
+        dir = StepDir.FWD if ctx.commit_vel > 0 else StepDir.REV
+        a_out = -math.copysign(cfg.max_decel, ctx.commit_vel)
+        steps_frac = travel_linaccel(ctx.commit_vel, 0, a_out)
+        # TODO: It would be better to round away from zero, but it's not
+        # convenient with numpy or the std lib.  So, we just always add one
+        # extra step.
+        steps = int(np.trunc(steps_frac) + math.copysign(1, steps_frac))
+
         deadlines = (
             ctx.commit_deadline
-            + pulse_times_trapz(
-                ctx.commit_vel,
-                0,
-                cfg.max_speed,
-                cfg.max_accel,
-                -cfg.max_decel,
-                steps,
-            )
-            * 1_000_000_000
+            + pulse_times_linaccel(steps, ctx.commit_vel, a_out) * 1_000_000_000
         ).astype(np.int64)
 
         velocities = np.empty_like(deadlines, dtype=np.float64)
         velocities[0] = ctx.commit_vel
         velocities[1:] = (
-            (1 if dir == _Direction.FWD else -1)
+            (1 if dir == StepDir.FWD else -1)
             * 1_000_000_000
             / (deadlines[1:] - deadlines[:-1])
         )
@@ -467,3 +566,11 @@ def _plan_abort(activity: Activity) -> StateFn:
             return _plan_dispatch
 
     return plan_abort
+
+
+def _nop_deadlines(
+    from_ns: int,
+    to_ns: int,
+    max_interval_ns: int,
+):
+    return np.arange(from_ns + max_interval_ns, to_ns, max_interval_ns)

--- a/src/telescope_control.py
+++ b/src/telescope_control.py
@@ -85,6 +85,8 @@ class Config:
     declination_axis: StepperAxis
 
     location: EarthLocation
+    predict_ns: int = 30_000_000_000
+    publish_interval: float = 0.25
 
 
 class Busy(Exception):
@@ -537,8 +539,7 @@ def _run_track(activity: _TelescopeActivity) -> StateFn:
             ctx.cond.notify_all()
 
         try:
-            # TODO: Make predict_dt_ns configurable.
-            predict_dt_ns = 30_000_000_000
+            predict_dt_ns = ctx.config.predict_ns
             predict_dt = predict_dt_ns * u.nanosecond  # pyright: ignore
 
             # Predict target location a short time in the future (to leave time
@@ -730,8 +731,7 @@ def _publish_state(ctx: _RunContext, conn: mpc.Connection):
 
     cfg = ctx.config
 
-    # TODO: Configurable interval
-    while not ctx.stop.wait(0.1):
+    while not ctx.stop.wait(cfg.publish_interval):
         with ctx.cond:
             target = ctx.target
             bearing_steps = ctx.bearing_steps

--- a/src/telescope_control.py
+++ b/src/telescope_control.py
@@ -113,6 +113,27 @@ class SolarSystemTarget(Target):
             return get_body(self.name, time, location)
 
 
+@dataclass
+class MPCQueryTarget(Target):
+    name: str
+
+    def coordinate(self, time: Time, location: EarthLocation):
+        from astroquery.mpc import MPC
+
+        eph = MPC.get_ephemeris(  # pyright: ignore
+            self.name,
+            start=time,
+            location=location,
+            number=1,
+        )
+
+        return SkyCoord(
+            ra=eph["RA"].to(u.hourangle)[0],
+            dec=eph["Dec"].to(u.deg)[0],
+            frame=ICRS,
+        )
+
+
 class TelescopeControl:
     _config: Config
     _conn: mpc.Connection | None


### PR DESCRIPTION
Adds trapezoidal motion profiles with target intercept.

---

I also added a new endpoint `/api/calibrate/bump?bearing=<int>&dec=<int>` (values are in motor steps). It's possible to call this while the telescope it actively tracking to make calibration adjustments.  It should be nice in a workflow like:

1. Decide what target you want to calibrate to.
2. Call `/api/calibrate/by_name?name=$target` to lie to the telescope and tell it that's what it's pointing at (by default it will start tracking).
3. Call `/api/calibrate/bump` repeatedly (would be nice in a UI with buttons) until the target is actually centered.

---

**IMPORTANT NOTE:** I switched all the in-project imports to be relative.  See e626db57ed7ed7b5e404f26d4418d48ae7d60d66.  This is the Python Way, but it has one important implication.  The program now needs to be run from the project root like:

```sh
python -m src.main
```

Eventually, we should restructure and rename the folders to be more "pythonic", but for now, it's fine to pretend the root package is named `src`.