### PR TITLE
Changed logging level and added fun messages

### DIFF
--- a/src/lib/stellarium.py
+++ b/src/lib/stellarium.py
@@ -11,7 +11,6 @@ from .. import telescope_control as tc
 
 _log = logging.getLogger(__name__)
 
-
 def decode_ra(x: int):
     """Convert Stellarium wire RA value to fractional seconds"""
     return (x % 0xFFFFFFFF) / 0xFFFFFFFF * 86_400
@@ -34,15 +33,15 @@ def encode_dec(x: float):
 
 async def serve(host: str, port: int, telescope: tc.TelescopeControl):
     async def handler(stream: trio.SocketStream):
-        _log.info("connected")
+        _log.info("Off world DHD and MALP Connected")
         try:
             async with trio.open_nursery() as n:
                 n.start_soon(_report_position_loop, stream, telescope)
                 n.start_soon(_receive_target_loop, stream, telescope)
         except (trio.BrokenResourceError, EndOfStream):
-            _log.info("disconnected")
+            _log.info("Off world DHD and MALP disconnected")
         except Exception as e:
-            _log.error("disconnecting", exc_info=e)
+            _log.error("Disconnecting off world DHD and MALP", exc_info=e)
 
     await trio.serve_tcp(handler, port=port, host=host)
 
@@ -122,7 +121,7 @@ async def _read_target(stream: trio.SocketStream, telescope: tc.TelescopeControl
         frame=ICRS,
     )
 
-    _log.info(f"target: {coord}")
+    _log.info(f"Manually dialing Stargate Coordinates from off world DHD: {coord}")
     telescope.track(tc.FixedTarget(coord))
 
     return True

--- a/src/logging.json
+++ b/src/logging.json
@@ -8,39 +8,39 @@
   "handlers": {
     "stderr": {
       "class": "logging.StreamHandler",
-      "level": "INFO",
+      "level": "DEBUG",
       "formatter": "simple",
       "stream": "ext://sys.stderr"
     }
   },
   "loggers": {
     "__main__": {
-      "level": "INFO",
+      "level": "DEBUG",
       "handlers": [
         "stderr"
       ],
-      "propagate": false
+      "propagate": true
     },
-    "lib.stellarium": {
-      "level": "INFO",
+    "src.lib.stellarium": {
+      "level": "DEBUG",
       "handlers": [
         "stderr"
       ],
-      "propagate": false
+      "propagate": true
     },
     "src.stepper": {
-      "level": "INFO",
+      "level": "DEBUG",
       "handlers": [
         "stderr"
       ],
-      "propagate": false
+      "propagate": true
     },
     "src.telescope_control": {
-      "level": "INFO",
+      "level": "DEBUG",
       "handlers": [
         "stderr"
       ],
-      "propagate": false
+      "propagate": true
     }
   }
 }

--- a/src/main.py
+++ b/src/main.py
@@ -129,4 +129,5 @@ def rpi_pulse(pins, fwd=1, rev=0):
 
 
 if __name__ == "__main__":
+    print('ᐰ Stargate SG-1 Deep Space Telescope')
     trio.run(main)

--- a/src/stepper.py
+++ b/src/stepper.py
@@ -282,7 +282,7 @@ class Stepper:
                 if sleep_ns < self._config.min_sleep_ns:
                     if d != StepDir.NOP:
                         # FIXME: Better telemetry
-                        _log.warn(f"running behind: {sleep_ns / 1_000_000_000}")
+                        _log.warn(f"MALP telemetry: {sleep_ns / 1_000_000_000}")
                     sleep_ns = self._config.min_sleep_ns
 
                 nsleep(sleep_ns)


### PR DESCRIPTION
```bash
(telescope-py3.11) ./run.sh 
ᐰ Stargate SG-1 Deep Space Telescope
[2024-01-30 14:38:33 -0500] [14193] [INFO] Running on http://0.0.0.0:8765 (CTRL + C to quit)
2024-01-30 14:38:33,789 - src.telescope_control.mp - DEBUG - Issuing top secret clearance...
2024-01-30 14:38:33,793 - src.telescope_control.mp - DEBUG - Top Secret clearence issued
2024-01-30 14:38:33,793 - src.telescope_control.mp - DEBUG - Welcome to Stargate HQ, Captain
2024-01-30 14:38:39,350 - src.lib.stellarium - INFO - Off world DHD and MALP Connected
2024-01-30 14:38:40,834 - src.telescope_control.mp - DEBUG - Entering gate coordinates
2024-01-30 14:38:40,835 - src.telescope_control.mp - DEBUG - Engaging chevrons
2024-01-30 14:38:40,835 - src.telescope_control.mp - DEBUG - Chevron 7 locked: -88765, 39265
[2024-01-30 14:38:40 -0500] [14193] [INFO] 127.0.0.1:38916 POST /api/calibrate/ 1.1 200 105 104586
[2024-01-30 14:38:40 -0500] [14193] [INFO] 127.0.0.1:38916 POST /api/calibrate/ 1.1 - - 105504
2024-01-30 14:38:40,838 - src.telescope_control.mp - DEBUG - Received orders from MALP: _Track(target=FixedTarget(coord=<SkyCoord (ICRS): (ra, dec) in deg
    (148.67265198, 69.1354597)>), id=UUID('ec82fe49-d454-494c-b24a-e4110a833a11'))
2024-01-30 14:38:40,839 - src.telescope_control.mp - DEBUG - Executing orders: _TelescopeActivity(_Track(target=FixedTarget(coord=<SkyCoord (ICRS): (ra, dec) in deg
    (148.67265198, 69.1354597)>), id=UUID('ec82fe49-d454-494c-b24a-e4110a833a11')), PENDING)
2024-01-30 14:38:40,840 - src.telescope_control.mp - INFO - Dialing gate address
2024-01-30 14:38:42,066 - src.telescope_control.mp - DEBUG - Adjusting for doppler shift: 30.00 s
2024-01-30 14:38:42,066 - src.stepper - WARNING - MALP telemetry: -0.688277035
2024-01-30 14:38:42,084 - src.telescope_control.mp - DEBUG - Adjusting for doppler shift: 30.00 s
2024-01-30 14:38:45,378 - src.telescope_control.mp - DEBUG - Received orders from MALP: _Track(target=FixedTarget(coord=<SkyCoord (ICRS): (ra, dec) in deg
    (148.67265198, 69.1354597)>), id=UUID('3b4d87ea-b4c3-456c-961c-d7e6a3aaaf0b'))
2024-01-30 14:38:45,378 - src.telescope_control.mp - DEBUG - Canceling current SG-1 orders: _TelescopeActivity(_Track(target=FixedTarget(coord=<SkyCoord (ICRS): (ra, dec) in deg
    (148.67265198, 69.1354597)>), id=UUID('ec82fe49-d454-494c-b24a-e4110a833a11')), ACTIVE)
2024-01-30 14:38:45,379 - src.telescope_control.mp - DEBUG - Executing orders: _TelescopeActivity(_Track(target=FixedTarget(coord=<SkyCoord (ICRS): (ra, dec) in deg
    (148.67265198, 69.1354597)>), id=UUID('3b4d87ea-b4c3-456c-961c-d7e6a3aaaf0b')), PENDING)
2024-01-30 14:38:47,067 - src.stepper - WARNING - MALP telemetry: -4.8548e-05
2024-01-30 14:38:47,068 - src.stepper - WARNING - MALP telemetry: -0.000898976
2024-01-30 14:38:47,068 - src.telescope_control.mp - INFO - Unscheduled incoming traveler.
2024-01-30 14:38:47,069 - src.telescope_control.mp - INFO - Dialing gate address
2024-01-30 14:38:47,101 - src.telescope_control.mp - DEBUG - Adjusting for doppler shift: 30.00 s
2024-01-30 14:38:47,664 - src.stepper - WARNING - MALP telemetry: -0.000353343
[2024-01-30 14:38:47 -0500] [14193] [INFO] 127.0.0.1:46330 POST /api/goto/ 1.1 200 99 2292593
[2024-01-30 14:38:47 -0500] [14193] [INFO] 127.0.0.1:46330 POST /api/goto/ 1.1 - - 2293159
2024-01-30 14:38:47,680 - src.telescope_control.mp - DEBUG - Adjusting for doppler shift: 30.00 s
[2024-01-30 14:38:50 -0500] [14193] [INFO] 127.0.0.1:46344 POST /api/idle 1.1 308 245 2225
[2024-01-30 14:38:50 -0500] [14193] [INFO] 127.0.0.1:46344 POST /api/idle 1.1 - - 2743
2024-01-30 14:38:50,184 - src.telescope_control - DEBUG - Shut down the stargate
2024-01-30 14:38:50,184 - src.telescope_control - DEBUG - Close the iris!
2024-01-30 14:38:50,184 - src.telescope_control.mp - DEBUG - Received orders from MALP: _Idle(id=UUID('21fb8525-06b0-425c-b17e-7148fb47ff65'))
2024-01-30 14:38:50,185 - src.telescope_control.mp - DEBUG - Canceling current SG-1 orders: _TelescopeActivity(_Track(target=FixedTarget(coord=<SkyCoord (ICRS): (ra, dec) in deg
    (148.67265198, 69.1354597)>), id=UUID('3b4d87ea-b4c3-456c-961c-d7e6a3aaaf0b')), ACTIVE)
2024-01-30 14:38:50,185 - src.telescope_control.mp - DEBUG - Executing orders: _TelescopeActivity(_Idle(id=UUID('21fb8525-06b0-425c-b17e-7148fb47ff65')), PENDING)
2024-01-30 14:38:52,145 - src.stepper - WARNING - MALP telemetry: -4.2519e-05
2024-01-30 14:38:52,146 - src.stepper - WARNING - MALP telemetry: -0.000789688
2024-01-30 14:38:52,146 - src.telescope_control.mp - INFO - Unscheduled incoming traveler.
2024-01-30 14:38:52,147 - src.telescope_control.mp - INFO - Closing the iris
2024-01-30 14:38:52,147 - src.telescope_control.mp - INFO - Wormhole disengaged
[2024-01-30 14:38:52 -0500] [14193] [INFO] 127.0.0.1:46356 POST /api/idle/ 1.1 200 50 1974570
[2024-01-30 14:38:52 -0500] [14193] [INFO] 127.0.0.1:46356 POST /api/idle/ 1.1 - - 1975065
^C2024-01-30 14:38:54,359 - src.telescope_control - INFO - Shut down the Stargate
2024-01-30 14:38:54,360 - src.telescope_control.mp - DEBUG - Received orders from MALP: _Stop(id=UUID('48deda36-685d-4ef1-9a5d-f562ae5aaf32'))
2024-01-30 14:38:54,360 - src.telescope_control.mp - DEBUG - Executing orders: _TelescopeActivity(_Stop(id=UUID('48deda36-685d-4ef1-9a5d-f562ae5aaf32')), PENDING)
2024-01-30 14:38:54,360 - src.telescope_control.mp - INFO - Shutting down the Stargate
2024-01-30 14:38:54,361 - src.telescope_control.mp - DEBUG - Disengaging chevrons
2024-01-30 14:38:54,361 - src.telescope_control.mp - DEBUG - Bearing motor deactivated
2024-01-30 14:38:54,362 - src.telescope_control.mp - DEBUG - Declination motor deactivated
2024-01-30 14:38:54,362 - src.telescope_control.mp - DEBUG - ᐰ Left Stargate Command ᐰ
```